### PR TITLE
DOCTYPE states

### DIFF
--- a/Code/src/main/java/com/html5parser/classes/token/DocTypeToken.java
+++ b/Code/src/main/java/com/html5parser/classes/token/DocTypeToken.java
@@ -39,4 +39,12 @@ public class DocTypeToken extends Token {
 	public void setForceQuircksFlag(boolean forceQuircksFlag) {
 		this.forceQuircksFlag = forceQuircksFlag;
 	}
+	
+	public void appendPublicIdentifier(int value) {
+		this.publicIdentifier = this.publicIdentifier.concat(String.valueOf(Character.toChars(value)));
+	}
+	
+	public void appendSystemIdentifier(int value) {
+		this.systemIdentifier = this.systemIdentifier.concat(String.valueOf(Character.toChars(value)));
+	}
 }

--- a/Code/src/main/java/com/html5parser/parser/Parser.java
+++ b/Code/src/main/java/com/html5parser/parser/Parser.java
@@ -29,17 +29,16 @@ public class Parser implements IParser {
 		ParserContext parserContext = new ParserContext();
 		Tokenizer tokenizer = new Tokenizer();
 		TreeConstructor treeConstructor = new TreeConstructor();
-		
+
 		BufferedReader in;
 		try {
-			
+
 			Document doc;
-			DocumentBuilderFactory dbf = DocumentBuilderFactory
-					.newInstance();
+			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 			DocumentBuilder builder = dbf.newDocumentBuilder();
 			doc = builder.newDocument();
 			parserContext.setDocument(doc);
-			
+
 			in = new BufferedReader(new InputStreamReader(stream, "UTF-8"));
 
 			int currentChar = in.read();
@@ -53,23 +52,22 @@ public class Parser implements IParser {
 				 * If not reconsume, then read next character of the stream
 				 */
 				if (!tokenizerContext.isFlagReconsumeCurrentInputCharacter()) {
-					tokenizerContext
-							.setFlagReconsumeCurrentInputCharacter(false);
 					currentChar = in.read();
 				}
 
-				
-				for(Token tok : parserContext.getTokenizerContext().getTokens()){
-					System.out.println(tok.getType()+" : "+tok.getValue());
-				}
-				
+				// If not specified by the spec, not reconsume in the next state
+				tokenizerContext.setFlagReconsumeCurrentInputCharacter(false);
+
 				/*
 				 * Consume all the tokens emited
 				 */
 				if (tokenizerContext.isFlagEmitToken()) {
 					
-					
-					
+					for (Token tok : parserContext.getTokenizerContext()
+							.getTokens()) {
+						System.out.println(tok.getType() + " : " + tok.getValue());
+					}
+
 					while (!parserContext.getTokenizerContext().getTokens()
 							.isEmpty()) {
 						/*
@@ -85,8 +83,7 @@ public class Parser implements IParser {
 					}
 					parserContext.getTokenizerContext().setFlagEmitToken(false);
 				}
-				
-				
+
 			}
 		} catch (UnsupportedEncodingException e) {
 			// TODO Auto-generated catch block

--- a/Code/src/main/java/com/html5parser/tokenizerStates/After_DOCTYPE_name_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/After_DOCTYPE_name_state.java
@@ -1,0 +1,141 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class After_DOCTYPE_name_state implements ITokenizerState {
+
+	/**
+	 * The value of this variable is publicHex or system.
+	 * This is compared to the six characters after the DOCTYPE keyword
+	 */
+	private int[] afterDOCTYPE_characters;
+	private final int[] publicHex = { 0x0050, 0x0055, 0x0042, 0x004C, 0x0049,
+			0x0043 };
+	private final int[] system = { 0x0053, 0x0059, 0x0053, 0x0054, 0x0045,
+			0x004D };
+
+	private int afterDOCTYPE_characters_Index = 0;
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		int currentChar = tokenizerContext.getCurrentInputCharacter();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// U+0009 CHARACTER TABULATION (tab)
+		case TAB:
+
+			// U+000A LINE FEED (LF)
+		case LF:
+
+			// U+000C FORM FEED (FF)
+		case FF:
+
+			// U+0020 SPACE
+			// Ignore the character.
+		case SPACE:
+			// Ignore the character.
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Switch to the data state. Emit the current DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Set the DOCTYPE token's
+		// force-quirks flag to on. Emit that DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		default:
+			if (afterDOCTYPE_characters == null) {
+				if (currentChar == 0x0050 || currentChar == 0x0070) {// character
+																		// P or
+																		// p
+					afterDOCTYPE_characters = publicHex;
+					afterDOCTYPE_characters_Index = afterDOCTYPE_characters_Index + 1;
+					break;
+				} else if (currentChar == 0x0053 || currentChar == 0x0073) {// character
+																			// S
+																			// or
+																			// s
+					afterDOCTYPE_characters = system;
+					afterDOCTYPE_characters_Index = afterDOCTYPE_characters_Index + 1;
+					break;
+				}
+
+			} else {
+				if (afterDOCTYPE_characters_Index <= 5 // for the next 6
+														// characters
+						&& (afterDOCTYPE_characters[afterDOCTYPE_characters_Index] == currentChar || afterDOCTYPE_characters[afterDOCTYPE_characters_Index]+ 0x0020 == currentChar )) {
+					afterDOCTYPE_characters_Index++;
+					if (afterDOCTYPE_characters_Index == 6) {
+						// If the six characters starting from the current input
+						// character
+						// are
+						// an ASCII case-insensitive match for the word
+						// "PUBLIC", then
+						// consume
+						// those characters and switch to the after DOCTYPE
+						// public
+						// keyword
+						// state.
+						if (afterDOCTYPE_characters[0] == 0x0050) {
+							tokenizerContext
+									.setNextState(factory
+											.getState(TokenizerState.After_DOCTYPE_public_keyword_state));
+						}
+						// Otherwise, if the six characters starting from the
+						// current
+						// input
+						// character are an ASCII case-insensitive match for the
+						// word
+						// "SYSTEM", then consume those characters and switch to
+						// the
+						// after
+						// DOCTYPE system keyword state.
+						else {
+							tokenizerContext
+									.setNextState(factory
+											.getState(TokenizerState.After_DOCTYPE_system_keyword_state));
+						}
+					}
+					break;
+				}
+			}
+
+			// Otherwise, this is a parse error. Set the DOCTYPE token's
+			// force-quirks flag to on. Switch to the bogus DOCTYPE state.
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Bogus_DOCTYPE_state));
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/After_DOCTYPE_public_identifier_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/After_DOCTYPE_public_identifier_state.java
@@ -1,0 +1,102 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class After_DOCTYPE_public_identifier_state implements ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		tokenizerContext.getCurrentInputCharacter();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// U+0009 CHARACTER TABULATION (tab)
+		case TAB:
+
+			// U+000A LINE FEED (LF)
+		case LF:
+
+			// U+000C FORM FEED (FF)
+		case FF:
+
+			// U+0020 SPACE
+			// Switch to the between DOCTYPE public and system identifiers
+			// state.
+		case SPACE:
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.Between_DOCTYPE_public_and_system_identifiers_state));
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Switch to the data state. Emit the current DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// U+0022 QUOTATION MARK (")
+		// Parse error. Set the DOCTYPE token's system identifier to the empty
+		// string (not missing), then switch to the DOCTYPE system identifier
+		// (double-quoted) state.
+		case QUOTATION_MARK:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			((DocTypeToken) tokenizerContext.getCurrentToken())
+					.setPublicIdentifier("");
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.DOCTYPE_system_identifier_double_quoted_state));
+			break;
+
+		// "'" (U+0027)
+		// Parse error. Set the DOCTYPE token's system identifier to the empty
+		// string (not missing), then switch to the DOCTYPE system identifier
+		// (single-quoted) state.
+		case APOSTROPHE:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			((DocTypeToken) tokenizerContext.getCurrentToken())
+					.setPublicIdentifier("");
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.DOCTYPE_system_identifier_single_quoted_state));
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Set the DOCTYPE token's
+		// force-quirks flag to on. Emit that DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the bogus DOCTYPE state.
+		default:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Bogus_DOCTYPE_state));
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/After_DOCTYPE_public_keyword_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/After_DOCTYPE_public_keyword_state.java
@@ -1,0 +1,105 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class After_DOCTYPE_public_keyword_state implements ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		tokenizerContext.getCurrentInputCharacter();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// U+0009 CHARACTER TABULATION (tab)
+		case TAB:
+
+			// U+000A LINE FEED (LF)
+		case LF:
+
+			// U+000C FORM FEED (FF)
+		case FF:
+
+			// U+0020 SPACE
+			// Switch to the before DOCTYPE public identifier state.
+		case SPACE:
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.Before_DOCTYPE_public_identifier_state));
+			break;
+
+		// U+0022 QUOTATION MARK (")
+		// Parse error. Set the DOCTYPE token's public identifier to the empty
+		// string (not missing), then switch to the DOCTYPE public identifier
+		// (double-quoted) state.
+		case QUOTATION_MARK:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			((DocTypeToken) tokenizerContext.getCurrentToken())
+					.setPublicIdentifier("");
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.DOCTYPE_public_identifier_double_quoted_state));
+			break;
+
+		// "'" (U+0027)
+		// Parse error. Set the DOCTYPE token's public identifier to the empty
+		// string (not missing), then switch to the DOCTYPE public identifier
+		// (single-quoted) state.
+		case APOSTROPHE:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			((DocTypeToken) tokenizerContext.getCurrentToken())
+					.setPublicIdentifier("");
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.DOCTYPE_public_identifier_single_quoted_state));
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the data state. Emit that DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Set the DOCTYPE token's
+		// force-quirks flag to on. Emit that DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the bogus DOCTYPE state.
+		default:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Bogus_DOCTYPE_state));
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/After_DOCTYPE_system_identifier_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/After_DOCTYPE_system_identifier_state.java
@@ -1,0 +1,71 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class After_DOCTYPE_system_identifier_state implements ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		tokenizerContext.getCurrentInputCharacter();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// U+0009 CHARACTER TABULATION (tab)
+		case TAB:
+
+			// U+000A LINE FEED (LF)
+		case LF:
+
+			// U+000C FORM FEED (FF)
+		case FF:
+
+			// U+0020 SPACE
+			// Ignore the character.
+		case SPACE:
+			// Ignore the character.
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Switch to the data state. Emit the current DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Set the DOCTYPE token's
+		// force-quirks flag to on. Emit that DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Parse error. Switch to the bogus DOCTYPE state. (This does not set
+		// the DOCTYPE token's force-quirks flag to on.)
+		default:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Bogus_DOCTYPE_state));
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/After_DOCTYPE_system_keyword_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/After_DOCTYPE_system_keyword_state.java
@@ -1,0 +1,105 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class After_DOCTYPE_system_keyword_state implements ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		tokenizerContext.getCurrentInputCharacter();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// U+0009 CHARACTER TABULATION (tab)
+		case TAB:
+
+			// U+000A LINE FEED (LF)
+		case LF:
+
+			// U+000C FORM FEED (FF)
+		case FF:
+
+			// U+0020 SPACE
+			// Switch to the before DOCTYPE system identifier state.
+		case SPACE:
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.Before_DOCTYPE_system_identifier_state));
+			break;
+
+		// U+0022 QUOTATION MARK (")
+		// Parse error. Set the DOCTYPE token's system identifier to the empty
+		// string (not missing), then switch to the DOCTYPE system identifier
+		// (double-quoted) state.
+		case QUOTATION_MARK:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			((DocTypeToken) tokenizerContext.getCurrentToken())
+					.setSystemIdentifier("");
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.DOCTYPE_system_identifier_double_quoted_state));
+			break;
+
+		// "'" (U+0027)
+		// Parse error. Set the DOCTYPE token's system identifier to the empty
+		// string (not missing), then switch to the DOCTYPE system identifier
+		// (single-quoted) state.
+		case APOSTROPHE:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			((DocTypeToken) tokenizerContext.getCurrentToken())
+					.setSystemIdentifier("");
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.DOCTYPE_system_identifier_single_quoted_state));
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the data state. Emit that DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Set the DOCTYPE token's
+		// force-quirks flag to on. Emit that DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the bogus DOCTYPE state.
+		default:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Bogus_DOCTYPE_state));
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/Before_DOCTYPE_name_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/Before_DOCTYPE_name_state.java
@@ -1,0 +1,100 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class Before_DOCTYPE_name_state implements ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		int currentChar = tokenizerContext.getCurrentInputCharacter();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// U+0009 CHARACTER TABULATION (tab)
+		case TAB:
+
+			// U+000A LINE FEED (LF)
+		case LF:
+
+			// U+000C FORM FEED (FF)
+		case FF:
+
+			// U+0020 SPACE
+			// Ignore the character.
+		case SPACE:
+			// Ignore the character.
+			break;
+
+		// U+0041 LATIN CAPITAL LETTER A through to U+005A LATIN CAPITAL LETTER
+		// Z
+		// Create a new DOCTYPE token. Set the token's name to the lowercase
+		// version of the current input character (add 0x0020 to the character's
+		// code point). Switch to the DOCTYPE name state.
+		case LATIN_CAPITAL_LETTER:
+			currentChar += 0x0020;
+			docToken = new DocTypeToken(currentChar);
+			tokenizerContext.setCurrentToken(docToken);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.DOCTYPE_name_state));
+			break;
+
+		// U+0000 NULL
+		// Parse error. Create a new DOCTYPE token. Set the token's name to a
+		// U+FFFD REPLACEMENT CHARACTER character. Switch to the DOCTYPE name
+		// state.
+		case NULL:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = new DocTypeToken(0xFFFD);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.DOCTYPE_name_state));
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Parse error. Create a new DOCTYPE token. Set its force-quirks flag to
+		// on. Switch to the data state. Emit the token.
+		case GREATER_THAN_SIGN:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = new DocTypeToken(null);
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Create a new DOCTYPE token.
+		// Set its force-quirks flag to on. Emit the token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = new DocTypeToken(null);
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.emitCurrentToken(docToken);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Create a new DOCTYPE token. Set the token's name to the current input
+		// character. Switch to the DOCTYPE name state.
+		default:
+			docToken = new DocTypeToken(currentChar);
+			tokenizerContext.setCurrentToken(docToken);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.DOCTYPE_name_state));
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/Before_DOCTYPE_public_identifier_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/Before_DOCTYPE_public_identifier_state.java
@@ -1,0 +1,101 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class Before_DOCTYPE_public_identifier_state implements ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		tokenizerContext.getCurrentInputCharacter();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// U+0009 CHARACTER TABULATION (tab)
+		case TAB:
+
+			// U+000A LINE FEED (LF)
+		case LF:
+
+			// U+000C FORM FEED (FF)
+		case FF:
+
+			// U+0020 SPACE
+			// Ignore the character.
+		case SPACE:
+			// Ignore the character.
+			break;
+
+		// U+0022 QUOTATION MARK (")
+		// Set the DOCTYPE token's public identifier to the empty string (not
+		// missing), then switch to the DOCTYPE public identifier
+		// (double-quoted) state.
+		case QUOTATION_MARK:
+			((DocTypeToken) tokenizerContext.getCurrentToken())
+					.setPublicIdentifier("");
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.DOCTYPE_public_identifier_double_quoted_state));
+			break;
+
+		// "'" (U+0027)
+		// Set the DOCTYPE token's public identifier to the empty string (not
+		// missing), then switch to the DOCTYPE public identifier
+		// (single-quoted) state.
+		case APOSTROPHE:
+			((DocTypeToken) tokenizerContext.getCurrentToken())
+					.setPublicIdentifier("");
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.DOCTYPE_public_identifier_single_quoted_state));
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the data state. Emit that DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Set the DOCTYPE token's
+		// force-quirks flag to on. Emit that DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the bogus DOCTYPE state.
+		default:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Bogus_DOCTYPE_state));
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/Before_DOCTYPE_system_identifier_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/Before_DOCTYPE_system_identifier_state.java
@@ -1,0 +1,101 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class Before_DOCTYPE_system_identifier_state implements ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		tokenizerContext.getCurrentInputCharacter();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// U+0009 CHARACTER TABULATION (tab)
+		case TAB:
+
+			// U+000A LINE FEED (LF)
+		case LF:
+
+			// U+000C FORM FEED (FF)
+		case FF:
+
+			// U+0020 SPACE
+			// Ignore the character.
+		case SPACE:
+			// Ignore the character.
+			break;
+
+		// U+0022 QUOTATION MARK (")
+		// Set the DOCTYPE token's system identifier to the empty string (not
+		// missing), then switch to the DOCTYPE system identifier
+		// (double-quoted) state.
+		case QUOTATION_MARK:
+			((DocTypeToken) tokenizerContext.getCurrentToken())
+					.setSystemIdentifier("");
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.DOCTYPE_system_identifier_double_quoted_state));
+			break;
+
+		// "'" (U+0027)
+		// Set the DOCTYPE token's system identifier to the empty string (not
+		// missing), then switch to the DOCTYPE system identifier
+		// (single-quoted) state.
+		case APOSTROPHE:
+			((DocTypeToken) tokenizerContext.getCurrentToken())
+					.setSystemIdentifier("");
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.DOCTYPE_system_identifier_single_quoted_state));
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the data state. Emit that DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Set the DOCTYPE token's
+		// force-quirks flag to on. Emit that DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the bogus DOCTYPE state.
+		default:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Bogus_DOCTYPE_state));
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/Between_DOCTYPE_public_and_system_identifiers_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/Between_DOCTYPE_public_and_system_identifiers_state.java
@@ -1,0 +1,97 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class Between_DOCTYPE_public_and_system_identifiers_state implements
+		ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// U+0009 CHARACTER TABULATION (tab)
+		case TAB:
+
+			// U+000A LINE FEED (LF)
+		case LF:
+
+			// U+000C FORM FEED (FF)
+		case FF:
+
+			// U+0020 SPACE
+			// Ignore the character.
+		case SPACE:
+			// Ignore the character.
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Switch to the data state. Emit the current DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// U+0022 QUOTATION MARK (")
+		// Set the DOCTYPE token's system identifier to the empty string (not
+		// missing), then switch to the DOCTYPE system identifier
+		// (double-quoted) state.
+		case QUOTATION_MARK:
+			((DocTypeToken) tokenizerContext.getCurrentToken())
+					.setSystemIdentifier("");
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.DOCTYPE_system_identifier_double_quoted_state));
+			break;
+
+		// "'" (U+0027)
+		// Set the DOCTYPE token's system identifier to the empty string (not
+		// missing), then switch to the DOCTYPE system identifier
+		// (single-quoted) state.
+		case APOSTROPHE:
+			((DocTypeToken) tokenizerContext.getCurrentToken())
+					.setSystemIdentifier("");
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.DOCTYPE_system_identifier_single_quoted_state));
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Set the DOCTYPE token's
+		// force-quirks flag to on. Emit that DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the bogus DOCTYPE state.
+		default:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Bogus_DOCTYPE_state));
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/Bogus_DOCTYPE_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/Bogus_DOCTYPE_state.java
@@ -1,0 +1,45 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+
+public class Bogus_DOCTYPE_state implements ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Switch to the data state. Emit the current DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// EOF
+		// Switch to the data state. Emit the DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Ignore the character.
+		default:
+			// Ignore the character.
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/DOCTYPE_name_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/DOCTYPE_name_state.java
@@ -1,0 +1,89 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class DOCTYPE_name_state implements ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		int currentChar = tokenizerContext.getCurrentInputCharacter();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// U+0009 CHARACTER TABULATION (tab)
+		case TAB:
+
+			// U+000A LINE FEED (LF)
+		case LF:
+
+			// U+000C FORM FEED (FF)
+		case FF:
+
+			// U+0020 SPACE
+			// Switch to the after DOCTYPE name state.
+		case SPACE:
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.After_DOCTYPE_name_state));
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Switch to the data state. Emit the current DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// U+0041 LATIN CAPITAL LETTER A through to U+005A LATIN CAPITAL LETTER
+		// Z
+		// Append the lowercase version of the current input character (add
+		// 0x0020 to the character's code point) to the current DOCTYPE token's
+		// name.
+		case LATIN_CAPITAL_LETTER:
+			currentChar += 0x0020;
+			tokenizerContext.getCurrentToken().appendValue(currentChar);
+			break;
+
+		// U+0000 NULL
+		// Parse error. Append a U+FFFD REPLACEMENT CHARACTER character to the
+		// current DOCTYPE token's name.
+		case NULL:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.appendValue(0xFFFD);
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Set the DOCTYPE token's
+		// force-quirks flag to on. Emit that DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Append the current input character to the current DOCTYPE token's
+		// name.
+		default:
+			tokenizerContext.getCurrentToken().appendValue(currentChar);
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/DOCTYPE_public_identifier_double_quoted_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/DOCTYPE_public_identifier_double_quoted_state.java
@@ -1,0 +1,77 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class DOCTYPE_public_identifier_double_quoted_state implements
+		ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		int currentChar = tokenizerContext.getCurrentInputCharacter();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// U+0022 QUOTATION MARK (")
+		// Switch to the after DOCTYPE public identifier state.
+		case QUOTATION_MARK:
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.After_DOCTYPE_public_identifier_state));
+			break;
+
+		// U+0000 NULL
+		// Parse error. Append a U+FFFD REPLACEMENT CHARACTER character to the
+		// current DOCTYPE token's public identifier.
+		case NULL:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.appendPublicIdentifier(0xFFFD);
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the data state. Emit that DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Set the DOCTYPE token's
+		// force-quirks flag to on. Emit that DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Append the current input character to the current DOCTYPE token's
+		// public identifier.
+		default:
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.appendPublicIdentifier(currentChar);
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/DOCTYPE_public_identifier_single_quoted_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/DOCTYPE_public_identifier_single_quoted_state.java
@@ -1,0 +1,77 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class DOCTYPE_public_identifier_single_quoted_state implements
+		ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		int currentChar = tokenizerContext.getCurrentInputCharacter();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// "'" (U+0027)
+		// Switch to the after DOCTYPE public identifier state.
+		case APOSTROPHE:
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.After_DOCTYPE_public_identifier_state));
+			break;
+
+		// U+0000 NULL
+		// Parse error. Append a U+FFFD REPLACEMENT CHARACTER character to the
+		// current DOCTYPE token's public identifier.
+		case NULL:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.appendPublicIdentifier(0xFFFD);
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the data state. Emit that DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Set the DOCTYPE token's
+		// force-quirks flag to on. Emit that DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Append the current input character to the current DOCTYPE token's
+		// public identifier.
+		default:
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.appendPublicIdentifier(currentChar);
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/DOCTYPE_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/DOCTYPE_state.java
@@ -1,0 +1,67 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class DOCTYPE_state implements ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		tokenizerContext.getCurrentInputCharacter();
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+		
+		// U+0009 CHARACTER TABULATION (tab)
+		// Switch to the character reference in data state.
+		case TAB:
+			
+		// U+000A LINE FEED (LF)
+		// Switch to the character reference in data state.
+		case LF:
+			
+		// U+000C FORM FEED (FF)
+		// Switch to the character reference in data state.
+		case FF:
+			
+		// U+0020 SPACE
+		// Switch to the character reference in data state.
+		case SPACE:
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Before_DOCTYPE_name_state));
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Create a new DOCTYPE token.
+		// Set its force-quirks flag to on. Emit the token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			DocTypeToken docToken = new DocTypeToken(null);
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.emitCurrentToken(docToken);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Parse error. Switch to the before DOCTYPE name state. Reconsume the
+		// character.
+		default:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Before_DOCTYPE_name_state));
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/DOCTYPE_system_identifier_double_quoted_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/DOCTYPE_system_identifier_double_quoted_state.java
@@ -1,0 +1,77 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class DOCTYPE_system_identifier_double_quoted_state implements
+		ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		int currentChar = tokenizerContext.getCurrentInputCharacter();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// U+0022 QUOTATION MARK (")
+		// Switch to the after DOCTYPE system identifier state.
+		case QUOTATION_MARK:
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.After_DOCTYPE_system_identifier_state));
+			break;
+
+		// U+0000 NULL
+		// Parse error. Append a U+FFFD REPLACEMENT CHARACTER character to the
+		// current DOCTYPE token's system identifier.
+		case NULL:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.appendSystemIdentifier(0xFFFD);
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the data state. Emit that DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Set the DOCTYPE token's
+		// force-quirks flag to on. Emit that DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Append the current input character to the current DOCTYPE token's
+		// public identifier.
+		default:
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.appendPublicIdentifier(currentChar);
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}

--- a/Code/src/main/java/com/html5parser/tokenizerStates/DOCTYPE_system_identifier_single_quoted_state.java
+++ b/Code/src/main/java/com/html5parser/tokenizerStates/DOCTYPE_system_identifier_single_quoted_state.java
@@ -1,0 +1,77 @@
+package com.html5parser.tokenizerStates;
+
+import com.html5parser.classes.ParserContext;
+import com.html5parser.classes.TokenizerContext;
+import com.html5parser.classes.TokenizerState;
+import com.html5parser.classes.token.DocTypeToken;
+import com.html5parser.factories.TokenizerStateFactory;
+import com.html5parser.interfaces.ITokenizerState;
+import com.html5parser.parseError.ParseErrorType;
+
+public class DOCTYPE_system_identifier_single_quoted_state implements
+		ITokenizerState {
+
+	public ParserContext process(ParserContext context) {
+		TokenizerStateFactory factory = TokenizerStateFactory.getInstance();
+		TokenizerContext tokenizerContext = context.getTokenizerContext();
+		int currentChar = tokenizerContext.getCurrentInputCharacter();
+		DocTypeToken docToken = null;
+
+		switch (tokenizerContext.getCurrentASCIICharacter()) {
+
+		// "'" (U+0027)
+		// Switch to the after DOCTYPE system identifier state.
+		case APOSTROPHE:
+			tokenizerContext
+					.setNextState(factory
+							.getState(TokenizerState.After_DOCTYPE_system_identifier_state));
+			break;
+
+		// U+0000 NULL
+		// Parse error. Append a U+FFFD REPLACEMENT CHARACTER character to the
+		// current DOCTYPE token's system identifier.
+		case NULL:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.appendSystemIdentifier(0xFFFD);
+			break;
+
+		// U+003E GREATER-THAN SIGN (>)
+		// Parse error. Set the DOCTYPE token's force-quirks flag to on. Switch
+		// to the data state. Emit that DOCTYPE token.
+		case GREATER_THAN_SIGN:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			tokenizerContext.setFlagEmitToken(true);
+			break;
+
+		// EOF
+		// Parse error. Switch to the data state. Set the DOCTYPE token's
+		// force-quirks flag to on. Emit that DOCTYPE token. Reconsume the EOF
+		// character.
+		case EOF:
+			context.addParseErrors(ParseErrorType.UnexpectedInputCharacter);
+			tokenizerContext.setNextState(factory
+					.getState(TokenizerState.Data_state));
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.setForceQuircksFlag(true);
+			tokenizerContext.setFlagEmitToken(true);
+			tokenizerContext.setFlagReconsumeCurrentInputCharacter(true);
+			break;
+
+		// Anything else
+		// Append the current input character to the current DOCTYPE token's
+		// public identifier.
+		default:
+			docToken = (DocTypeToken) tokenizerContext.getCurrentToken();
+			docToken.appendPublicIdentifier(currentChar);
+			break;
+		}
+
+		context.setTokenizerContext(tokenizerContext);
+		return context;
+	}
+}


### PR DESCRIPTION
Add DOCTYPE states
Fix Parser.java to set the reconsume to false after reading next
character
Update TokenizerTestghtml5libsuite.java. Now can test multiple files.
